### PR TITLE
Add "OCI media types" support in "put-multiarch"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: docker-library/official-images
-          ref: abe06f9a56327c6b8805437a6ddc47b2e8a2de5f
+          ref: b851f53b765e622928a94663d425ddbe37aceb3b
           path: oi
       - run: echo "BASHBREW_LIBRARY=$PWD/oi/library" >> "$GITHUB_ENV"
       - run: docker run -dit --name registry --restart always -p 5000:5000 registry

--- a/lib/Bashbrew/RegistryUserAgent.pm
+++ b/lib/Bashbrew/RegistryUserAgent.pm
@@ -32,12 +32,18 @@ use constant MEDIA_MANIFEST_LIST => 'application/vnd.docker.distribution.manifes
 use constant MEDIA_MANIFEST_V2   => 'application/vnd.docker.distribution.manifest.v2+json';
 use constant MEDIA_MANIFEST_V1   => 'application/vnd.docker.distribution.manifest.v1+json';
 use constant MEDIA_FOREIGN_LAYER => 'application/vnd.docker.image.rootfs.foreign.diff.tar.gzip';
+# https://github.com/opencontainers/image-spec/blob/v1.0.2/media-types.md
+use constant MEDIA_OCI_INDEX_V1    => 'application/vnd.oci.image.index.v1+json';
+use constant MEDIA_OCI_MANIFEST_V1 => 'application/vnd.oci.image.manifest.v1+json';
 
 # this is "normally" handled for us by https://github.com/tianon/dockerhub-public-proxy but is necessary for alternative registries
 my $acceptHeader = [
 	MEDIA_MANIFEST_LIST,
 	MEDIA_MANIFEST_V2,
 	MEDIA_MANIFEST_V1,
+	MEDIA_OCI_INDEX_V1,
+	MEDIA_OCI_MANIFEST_V1,
+	'*/*', # Docker Hub doesn't (currently, as of 2022-10-20) support this catch-all, but other registries do
 ];
 
 sub _retry_simple_req_p ($self, $tries, $method, @args) {

--- a/test-localhost.sh
+++ b/test-localhost.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 # docker run -dit --name registry --restart always -p 5000:5000 registry
 
-arches=( amd64 arm32v5 arm32v6 arm32v7 arm64v8 i386 mips64le ppc64le s390x )
+arches=( amd64 arm32v5 arm32v6 arm32v7 arm64v8 i386 mips64le ppc64le riscv64 s390x )
 image='busybox:latest'
 target='localhost:5000'
 
@@ -12,6 +12,8 @@ for arch in "${arches[@]}"; do
 	docker image inspect "$arch/$image" &> /dev/null || docker pull "$arch/$image"
 	docker tag "$arch/$image" "$target/$arch/$image"
 	docker push "$target/$arch/$image"
+	#skopeo copy --format oci "docker://docker.io/$arch/$image" --dest-tls-verify=false "docker://$target/$arch/$image"
+	#skopeo copy --format v2s2 "docker://docker.io/$arch/$image" --dest-tls-verify=false "docker://$target/$arch/$image"
 	[ -z "$BASHBREW_ARCH_NAMESPACES" ] || BASHBREW_ARCH_NAMESPACES+=', '
 	BASHBREW_ARCH_NAMESPACES+="$arch = $target/$arch"
 done


### PR DESCRIPTION
As a detail of implementation, after we've gathered up the list of manifests to include in our list/index, we choose a media type for the wrapper (OCI vs Docker) based on whether the media type of the first manifest in our list is OCI or Docker (hopefully avoiding too many cases of "OCI index contains Docker manifest" or "Docker manifest list contains OCI manifest").