### PR TITLE
Add more OCI-related functionality and better protection against misbehaving per-architecture servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: docker build --pull --tag oisupport/perl-bashbrew .
-      - uses: actions/checkout@v3
-        with:
-          repository: docker-library/official-images
-          ref: b851f53b765e622928a94663d425ddbe37aceb3b
-          path: oi
-      - run: echo "BASHBREW_LIBRARY=$PWD/oi/library" >> "$GITHUB_ENV"
-      - run: docker run -dit --name registry --restart always -p 5000:5000 registry
-      - run: ./test-localhost.sh
+      - name: Install "bashbrew"
+        run: |
+          git clone --depth 1 https://github.com/docker-library/bashbrew.git -b master bashbrew
+          ./bashbrew/bashbrew.sh --version > /dev/null
+          export PATH="$PWD/bashbrew/bin:$PATH"
+          echo "PATH=$PATH" >> "$GITHUB_ENV"
+          bashbrew --version
+      - name: Clone DOI
+        run: |
+          git clone --depth 1 https://github.com/docker-library/official-images.git oi
+          export BASHBREW_LIBRARY="$PWD/oi/library"
+          echo "BASHBREW_LIBRARY=$BASHBREW_LIBRARY" >> "$GITHUB_ENV"
+          bashbrew from hello-world:latest > /dev/null
+      - run: docker run -dit --name registry --restart always -p 5000:5000 --env REGISTRY_VALIDATION_MANIFESTS_URLS_ALLOW='["^.*$"]' --env REGISTRY_VALIDATION_MANIFESTS_URLS_DENY='[]' registry
+      - run: ./test-localhost.sh hello-world:latest # includes Windows images
+      - run: ./test-localhost.sh hello-world:nanoserver-ltsc2022 # forces an "os.version from the config blob" lookup
+      - run: ./test-localhost.sh busybox:latest # includes three separate "linux/arm" variants

--- a/lib/Bashbrew/RegistryUserAgent.pm
+++ b/lib/Bashbrew/RegistryUserAgent.pm
@@ -36,6 +36,13 @@ use constant MEDIA_FOREIGN_LAYER => 'application/vnd.docker.image.rootfs.foreign
 use constant MEDIA_OCI_INDEX_V1    => 'application/vnd.oci.image.index.v1+json';
 use constant MEDIA_OCI_MANIFEST_V1 => 'application/vnd.oci.image.manifest.v1+json';
 
+sub is_media_image_manifest ($mediaType) {
+	return $mediaType eq MEDIA_OCI_MANIFEST_V1 || $mediaType eq MEDIA_MANIFEST_V2 || $mediaType eq MEDIA_MANIFEST_V1;
+}
+sub is_media_image_list ($mediaType) {
+	return $mediaType eq MEDIA_OCI_INDEX_V1 || $mediaType eq MEDIA_MANIFEST_LIST;
+}
+
 # this is "normally" handled for us by https://github.com/tianon/dockerhub-public-proxy but is necessary for alternative registries
 my $acceptHeader = [
 	MEDIA_MANIFEST_LIST,

--- a/test-localhost.sh
+++ b/test-localhost.sh
@@ -3,17 +3,49 @@ set -Eeuo pipefail
 
 # docker run -dit --name registry --restart always -p 5000:5000 registry
 
-arches=( amd64 arm32v5 arm32v6 arm32v7 arm64v8 i386 mips64le ppc64le riscv64 s390x )
-image='busybox:latest'
+# docker run -dit --name registry --restart always -p 5000:5000 --env REGISTRY_VALIDATION_MANIFESTS_URLS_ALLOW='["^.*$"]' --env REGISTRY_VALIDATION_MANIFESTS_URLS_DENY='[]' registry
+
+image="${1:-'hello-world:latest'}"
+registry='docker.io'
 target='localhost:5000'
+
+arches="$(bashbrew cat --format '{{- range .Entries }}{{ json .Architectures -}}{{- end -}}' "$image")"
+arches="$(jq <<<"$arches" -sr 'flatten | unique | map(@sh) | join(" ")')"
+eval "arches=( $arches )"
+
+if ! command -v crane &> /dev/null; then
+	if ! docker image inspect --format '.' gcr.io/go-containerregistry/crane &> /dev/null; then
+		docker pull gcr.io/go-containerregistry/crane
+	fi
+	crane() {
+		local args=(
+			--interactive --rm
+			--user "$RANDOM:$RANDOM"
+			--network host
+			--security-opt no-new-privileges
+		)
+		if [ -t 0 ] && [ -t 1 ]; then
+			args+=( --tty )
+		fi
+		docker run "${args[@]}" gcr.io/go-containerregistry/crane "$@"
+	}
+fi
 
 BASHBREW_ARCH_NAMESPACES=
 for arch in "${arches[@]}"; do
-	docker image inspect "$arch/$image" &> /dev/null || docker pull "$arch/$image"
-	docker tag "$arch/$image" "$target/$arch/$image"
-	docker push "$target/$arch/$image"
-	#skopeo copy --format oci "docker://docker.io/$arch/$image" --dest-tls-verify=false "docker://$target/$arch/$image"
-	#skopeo copy --format v2s2 "docker://docker.io/$arch/$image" --dest-tls-verify=false "docker://$target/$arch/$image"
+	if [ "$arch" = 'windows-amd64' ]; then
+		src="$registry/winamd64/$image"
+	else
+		src="$registry/$arch/$image"
+	fi
+	trg="$target/$arch/$image"
+
+	crane copy "$src" --insecure "$trg"
+
+	# skopeo appears to be the only one of these "registry copy" tools willing to do format conversions between Docker and OCI 👀
+	#skopeo copy --multi-arch all --format oci "docker://$src" --dest-tls-verify=false "docker://$trg"
+	#skopeo copy --multi-arch all --format v2s2 "docker://$src" --dest-tls-verify=false "docker://$trg"
+
 	[ -z "$BASHBREW_ARCH_NAMESPACES" ] || BASHBREW_ARCH_NAMESPACES+=', '
 	BASHBREW_ARCH_NAMESPACES+="$arch = $target/$arch"
 done


### PR DESCRIPTION
This changes the "manifest list" consumption code to ensure that if `riscv64/hello-world` contains a manifest list for example, that we only pull the `linux/riscv64` images (and related artifacts, see below) from it.

This also adds support for preserving artifacts/attestations in the format (optionally) generated by buildkit (https://github.com/moby/buildkit/pull/2983, https://github.com/moby/buildkit/pull/3129, etc).