### PR TITLE
Sort Windows images by os.version in image indexes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM perl:5.28-slim
+FROM perl:5.32-slim
 
 RUN set -eux; \
 	apt-get update; \
@@ -63,7 +63,16 @@ ENV LIBEV_FLAGS 4
 WORKDIR /opt/perl-bashbrew
 COPY lib/Bashbrew.pm lib/
 COPY Makefile.PL ./
-RUN cpanm --installdeps .
+RUN set -eux; \
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+# the Dpkg module needs patch
+	apt-get install -y --no-install-recommends patch; \
+	cpanm -v --installdeps .; \
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove
+
 COPY . .
 RUN cpanm .
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,7 @@ WriteMakefile(
 		'Test::More' => 0,
 	},
 	PREREQ_PM => {
+		'Dpkg::Version' => 0,
 		'EV' => 0,
 		'IO::Socket::IP' => 0,
 		'IO::Socket::SSL' => 0,


### PR DESCRIPTION
We aren't perfect at ensuring that the Windows versions within a set of `SharedTags` in properly sorted in descending order in the `library/` files. This will just ensure that the Windows versions are in the correct order when we miss it. So, `ltsc2022` and then `1809` will be listed in the image indexes.

Example image with Windows images in the opposite order: https://explore.ggcr.dev/?image=caddy@sha256:bcf45332e3ebd42456f5fe63be2175ebfee971d85c2cd1bd837dd0beb422fa1c&mt=application%2Fvnd.docker.distribution.manifest.list.v2%2Bjson&size=1927

Perl bump and `patch` build dep are required for the `Dpkg` module so that we can use https://metacpan.org/pod/Dpkg::Version for `os.version` comparison.